### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python"

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Welcome to ProjectDarkErebus!
 - I am currently pulling statistics from various sources and running them through multiple machine learning algorithms.
 - So far, I have successfully implemented Logistic Regression, Linear SVM, RBF SVM, Random Forrest, XGBoost, K Nearest Neighbor, and Gaussian Naive Bayes.
 - I am working to add Neural Networks.
+
+
+
+[![Run on Repl.it](https://repl.it/badge/github/DaCryptoSpartan/ProjectDarkErebus)](https://repl.it/github/DaCryptoSpartan/ProjectDarkErebus)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@TylerBelfield/ProjectDarkErebus-1).